### PR TITLE
bug1572190 tcw: use new tc rootUrl and clients

### DIFF
--- a/modules/generic_worker/templates/generic-worker.config.erb
+++ b/modules/generic_worker/templates/generic-worker.config.erb
@@ -22,7 +22,7 @@
   "publicIP": "<%= @ipaddress %>",
   "region": "",
   "requiredDiskSpaceMegabytes": 10240,
-  "rootURL": "https://taskcluster.net",
+  "rootURL": "https://firefox-ci-tc.services.mozilla.com",
   "runAfterUserCreation": "",
   "runTasksAsCurrentUser": true,
   "sentryProject": "generic-worker",

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_power_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_power_generic_worker.pp
@@ -35,12 +35,12 @@ class roles_profiles::profiles::gecko_t_osx_1014_power_generic_worker {
                 user => 'cltbld',
             }
 
-            $taskcluster_client_id    = lookup('generic_worker.gecko_t_osx_1014_power.taskcluster_client_id')
-            $taskcluster_access_token = lookup('generic_worker.gecko_t_osx_1014_power.taskcluster_access_token')
-            $livelog_secret           = lookup('generic_worker.gecko_t_osx_1014_power.livelog_secret')
-            $quarantine_client_id     = lookup('generic_worker.gecko_t_osx_1014_power.quarantine_client_id')
-            $quarantine_access_token  = lookup('generic_worker.gecko_t_osx_1014_power.quarantine_access_token')
-            $bugzilla_api_key         = lookup('generic_worker.gecko_t_osx_1014_power.bugzilla_api_key')
+            $taskcluster_client_id    = lookup('generic_worker.bitcar_gecko_t_osx_1014_power.taskcluster_client_id')
+            $taskcluster_access_token = lookup('generic_worker.bitcar_gecko_t_osx_1014_power.taskcluster_access_token')
+            $livelog_secret           = lookup('generic_worker.bitcar_gecko_t_osx_1014_power.livelog_secret')
+            $quarantine_client_id     = lookup('generic_worker.bitcar_gecko_t_osx_1014_power.quarantine_client_id')
+            $quarantine_access_token  = lookup('generic_worker.bitcar_gecko_t_osx_1014_power.quarantine_access_token')
+            $bugzilla_api_key         = lookup('generic_worker.bitcar_gecko_t_osx_1014_power.bugzilla_api_key')
 
             class { 'packages::zstandard':
                 version => '1.3.8',

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_power_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_power_generic_worker.pp
@@ -35,12 +35,12 @@ class roles_profiles::profiles::gecko_t_osx_1014_power_generic_worker {
                 user => 'cltbld',
             }
 
-            $taskcluster_client_id    = lookup('generic_worker.bitcar_gecko_t_osx_1014_power.taskcluster_client_id')
-            $taskcluster_access_token = lookup('generic_worker.bitcar_gecko_t_osx_1014_power.taskcluster_access_token')
-            $livelog_secret           = lookup('generic_worker.bitcar_gecko_t_osx_1014_power.livelog_secret')
-            $quarantine_client_id     = lookup('generic_worker.bitcar_gecko_t_osx_1014_power.quarantine_client_id')
-            $quarantine_access_token  = lookup('generic_worker.bitcar_gecko_t_osx_1014_power.quarantine_access_token')
-            $bugzilla_api_key         = lookup('generic_worker.bitcar_gecko_t_osx_1014_power.bugzilla_api_key')
+            $taskcluster_client_id    = lookup('generic_worker.bitbar_gecko_t_osx_1014_power.taskcluster_client_id')
+            $taskcluster_access_token = lookup('generic_worker.bitbar_gecko_t_osx_1014_power.taskcluster_access_token')
+            $livelog_secret           = lookup('generic_worker.bitbar_gecko_t_osx_1014_power.livelog_secret')
+            $quarantine_client_id     = lookup('generic_worker.bitbar_gecko_t_osx_1014_power.quarantine_client_id')
+            $quarantine_access_token  = lookup('generic_worker.bitbar_gecko_t_osx_1014_power.quarantine_access_token')
+            $bugzilla_api_key         = lookup('generic_worker.bitbar_gecko_t_osx_1014_power.bugzilla_api_key')
 
             class { 'packages::zstandard':
                 version => '1.3.8',


### PR DESCRIPTION
Switch macos mojave power workers to new TC rootUrl and client during TCW

Waiting to merge during TCW